### PR TITLE
Minor doc bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the cancel event handler. This simply removes from the DOM any elements found us
 the selector defined in the ```data-cancel-closest``` attribute:
 
 ```
-<a href="" data-cancel-closest=".edit-form" class="btn">
+<a href="#" data-cancel-closest=".edit-form" class="btn">
     Cancel
 </a>
 ```


### PR DESCRIPTION
Should use a `#` as the anchor href instead of a blank one to prevent unwanted page reloads if/when Javascript fails to load or run correctly.
