### PR TITLE
Replace html only

### DIFF
--- a/js/bootstrap-ajax.js
+++ b/js/bootstrap-ajax.js
@@ -3,21 +3,21 @@
  * ====================================================================
  * Copyright (c) 2012, Eldarion, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
- * 
+ *
  *     * Redistributions in binary form must reproduce the above copyright notice,
  *       this list of conditions and the following disclaimer in the documentation
  *       and/or other materials provided with the distribution.
- * 
+ *
  *     * Neither the name of Eldarion, Inc. nor the names of its contributors may
  *       be used to endorse or promote products derived from this software without
  *       specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,11 +46,11 @@
     if (!method) {
       method = 'get'
     }
-    
+
     spin($this)
-    
+
     e.preventDefault()
-    
+
     $.ajax({
       url: url,
       type: method,
@@ -64,19 +64,19 @@
       }
     })
   }
-  
+
   Ajax.prototype.submit = function (e) {
     var $this = $(this)
       , url = $this.attr('action')
       , method = $this.attr('method')
       , data = $this.serialize()
-     
+
     $this.find("input[type=submit],button[type=submit]").attr("disabled", "disabled")
-     
+
     spin($this)
-    
+
     e.preventDefault()
-    
+
     $.ajax({
       url: url,
       type: method,
@@ -91,16 +91,16 @@
       }
     })
   }
-  
+
   Ajax.prototype.cancel = function(e) {
     var $this = $(this)
       , selector = $this.attr('data-cancel-closest')
-    
+
     e.preventDefault()
-    
+
     $this.closest(selector).remove()
   }
-  
+
   if (typeof Spinner !== 'undefined') { // http://fgnass.github.com/spin.js/
     $.fn.spin = function(opts) {
       this.each(function() {
@@ -118,14 +118,14 @@
       return this
     }
   }
-  
+
   function spin($el) { // http://fgnass.github.com/spin.js/
     if ($.fn.spin !== undefined) {
       var spinner_selector = $el.attr('data-spinner')
         , spinner_selector_replace = $el.attr('data-spinner-replace')
         , spinner_selector_replace_closest = $el.attr('data-spinner-replace-closest')
         , opts = {lines: 11, length:0, width:6, radius:9, rotate:0, trail:89, speed:1.4}
-        
+
         if (spinner_selector) {
           $(spinner_selector).spin(opts)
         } else if (spinner_selector_replace) {
@@ -137,28 +137,32 @@
         }
     }
   }
-  
+
   function stop_spin($el) {
     if ($el.stop !== undefined) {
       $el.stop()
     }
   }
-  
+
   function processData(data, $el) {
     if (data.location) {
       window.location.href = data.location
     } else {
       var replace_selector = $el.attr('data-replace')
         , replace_closest_selector = $el.attr('data-replace-closest')
+        , replace_html_selector = $el.attr('data-replace-html')
         , append_selector = $el.attr('data-append')
         , refresh_selector = $el.attr('data-refresh')
         , refresh_closest_selector = $el.attr('data-refresh-closest')
-      
+
       if (replace_selector) {
         $(replace_selector).replaceWith(data.html)
       }
       if (replace_closest_selector) {
         $el.closest(replace_closest_selector).replaceWith(data.html)
+      }
+      if(replace_html_selector) {
+        $(replace_html_selector).html(data.html)
       }
       if (append_selector) {
         $(append_selector).append(data.html)
@@ -179,18 +183,22 @@
       }
     }
   }
-  
+
   function processError($el) {
     var msg = '<div class="alert alert-error">There was a server error.</div>'
       , replace_selector = $el.attr('data-replace')
       , replace_closest_selector = $el.attr('data-replace-closest')
+      , replace_html_selector = $el.attr('data-replace-html')
       , append_selector = $el.attr('data-append')
-    
+
     if (replace_selector) {
       $(replace_selector).replaceWith(msg)
     }
     if (replace_closest_selector) {
       $el.closest(replace_closest_selector).replaceWith(msg)
+    }
+    if(replace_html_selector) {
+      $(replace_html_selector).html(msg)
     }
     if (append_selector) {
       $(append_selector).append(msg)


### PR DESCRIPTION
Resolved my own issue:
It would be useful to be able to replace everything within a container, leaving the container intact.
ie. data-replace-html.

Didn't add the new response to the spin function though. You may like to take a look at that.
