### PR TITLE
Change jQuery version requirement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.13.0",
   "main": "./js/eldarion-ajax.min.js",
   "dependencies": {
-    "jquery": "~1.8.3"
+    "jquery": ">=1.8.3"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Using ~ unnecessarily restricts the acceptable version of jQuery to the 1.8 range, while test coverage goes beyond that.