### PR TITLE
Update, improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ Similar to `data.fragments`. Each fragment value replaces the `.html` attribute 
 
 Similar to `data.fragments`. Each fragment value is prepended to the element(s) found in the key CSS selector
 
+### Response Data Pro Tip
+
+Both `data.html` and `data.fragments` are processed in a single response.
+This gives you the ability to replace a submitted form with `data.html` content
+while also updating multiple fragments of content on the page.
+
 ## Action Attributes
 
 The following attributes are used by eldarion-ajax when processing supported [Actions](#actions).
@@ -418,12 +424,6 @@ Specify a URL which will return HTML content for the element.
 ```html
 <div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
 ```
-
-### Response Data Pro Tip
-
-Both `data.html` and `data.fragments` are processed in a single response.
-This gives you the ability to replace a submitted form with `data.html` content
-while also updating multiple fragments of content on the page.
 
 
 ## Handlers: A Batteries-Included Framework

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ require('eldarion-ajax');  // do this in your main bundle file and you'll be all
 
 There are three supported actions:
 
-1. `a.click`
-2. `form.submit`
-3. `a.cancel`
+1. [`a.click`](#a.click)
+2. [`form.submit`](#form.submit)
+3. [`a.cancel`](#a.cancel)
 
 ### `a.click`
 
@@ -214,9 +214,9 @@ event. Otherwise, the original data will be used.
 
 There are three data attributes looked for in the response JSON.
 
-1. [`location`](#data-location) - URL used for immediate redirection
-2. [`html`](#data-html) - content used when processing `html` Directives
-3. [`fragments`](#data-fragments) - additional content for the DOM
+1. [`location`](#data.location) - URL used for immediate redirection
+2. [`html`](#data.html) - content used when processing `html` Directives
+3. [`fragments`](#data.fragments) - additional content for the DOM
 
 ### `data.location`
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ from the DOM any elements found in the specified CSS selector.
 
 #### data-method
 
-Defines the request method, i.e. "GET" or "POST".
+Defines the request method, i.e. "POST". If this attribute is not provided,
+the request method defaults to "GET".
 
 ```html
 <a href="/tasks/2323/delete/" class="ajax" data-method="post">

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ require('eldarion-ajax');  // do this in your main bundle file and you'll be all
 
 There are three supported actions:
 
-1. [`a.click`](#a.click)
-2. [`form.submit`](#form.submit)
-3. [`a.cancel`](#a.cancel)
+1. [`a.click`](#aclick)
+2. [`form.submit`](#formsubmit)
+3. [`a.cancel`](#acancel)
 
 ### `a.click`
 
@@ -127,11 +127,11 @@ found using the selector defined in the `data-cancel-closest` attribute:
 
 These custom events allow you to customize eldarion-ajax behavior.
 
-1. `eldarion-ajax:begin`
-2. `eldarion-ajax:success`
-3. `eldarion-ajax:error`
-4. `eldarion-ajax:complete`
-5. `eldarion-ajax:modify-data`
+1. [`eldarion-ajax:begin`](#eldarion-ajaxbegin)
+2. [`eldarion-ajax:success`](#eldarion-ajaxsuccess)
+3. [`eldarion-ajax:error`](#eldarion-ajaxerror)
+4. [`eldarion-ajax:complete`](#eldarion-ajaxcomplete)
+5. [`eldarion-ajax:modify-data`](#eldarion-ajaxmodify-data)
 
 All events are triggered on the element that is declared to be ajax. For example
 on an anchor:
@@ -214,9 +214,9 @@ event. Otherwise, the original data will be used.
 
 There are three data attributes looked for in the response JSON.
 
-1. [`location`](#data.location) - URL used for immediate redirection
-2. [`html`](#data.html) - content used when processing `html` Directives
-3. [`fragments`](#data.fragments) - additional content for the DOM
+1. [`location`](#datalocation) - URL used for immediate redirection
+2. [`html`](#datahtml) - content used when processing `html` Directives
+3. [`fragments`](#datafragments) - additional content for the DOM
 
 ### `data.location`
 
@@ -231,7 +231,7 @@ of existing DOM element content. Exactly how `data.html` is used depends on one
 or more processing directives.
 
 Processing directives are defined by attributes added to the event-handling `class="ajax"` element.
-They are linked to handlers as described in [Handlers: A Framework](#handlers-a-framework).
+They are linked to handlers as described in [Handlers: A Batteries-Included Framework](#handlers-a-batteries-included-framework).
 
 Each processing directive is assigned a CSS selector. Since a CSS selector
 can be written to address multiple different blocks on the page at the same time,
@@ -425,7 +425,7 @@ This gives you the ability to replace a submitted form with `data.html` content
 while also updating multiple fragments of content on the page.
 
 
-## Handlers: A Batteries Included Framework
+## Handlers: A Batteries-Included Framework
 
 The eldarion-ajax [events](#events) allow you to code handlers which
 customize actions for server responses. Many handlers are included

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ trigger the "cancel" event handler. This simply removes from the DOM any element
 found using the selector defined in the `data-cancel-closest` attribute:
 
 ```html
-<a href="#" data-cancel-closest=".edit-form" class="btn btn-secondary ajax">
+<a href="#" data-cancel-closest=".edit-form" class="btn btn-secondary">
     Cancel
 </a>
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ require('eldarion-ajax');  // do this in your main bundle file and you'll be all
 
 ## Actions
 
-There are currently three actions supported:
+There are three supported actions:
 
 1. `a.click`
 2. `form.submit`
@@ -113,11 +113,11 @@ declared in the `form` tag.
 ### `a.cancel`
 
 Any `a` tag that has a `data-cancel-closest` attribute defined will
-trigger the cancel event handler. This simply removes from the DOM any elements
+trigger the "cancel" event handler. This simply removes from the DOM any elements
 found using the selector defined in the `data-cancel-closest` attribute:
 
 ```html
-<a href="#" data-cancel-closest=".edit-form" class="btn btn-secondary">
+<a href="#" data-cancel-closest=".edit-form" class="btn btn-secondary ajax">
     Cancel
 </a>
 ```
@@ -125,8 +125,7 @@ found using the selector defined in the `data-cancel-closest` attribute:
 
 ## Events
 
-There are three custom events that get triggered allowing you to customize the
-behavior of eldarion-ajax.
+These custom events allow you to customize eldarion-ajax behavior.
 
 1. `eldarion-ajax:begin`
 2. `eldarion-ajax:success`
@@ -134,14 +133,14 @@ behavior of eldarion-ajax.
 4. `eldarion-ajax:complete`
 5. `eldarion-ajax:modify-data`
 
-All events are triggered on the element that is declared to be ajax. For example,
-if you had a:
+All events are triggered on the element that is declared to be ajax. For example
+on an anchor:
 
 ```html
 <a href="/tasks/2323/delete/" class="ajax" data-method="post">
 ```
 
-link, the trigger would be fired on the `<a>` element. This, of course,
+the trigger would be fired on the `<a>` element. This event, of course,
 bubbles up, but allows you to easily listen only for events on particular tags.
 
 Every event also sends as its first parameter, the element itself, in case you
@@ -211,12 +210,227 @@ change the data at all, you must return new data from the function handling the
 event. Otherwise, the original data will be used.
 
 
+## Response Handling
+
+There are three data attributes looked for in the response JSON.
+
+1. [`location`](#data-location) - URL used for immediate redirection
+2. [`html`](#data-html) - content used when processing `html` Directives
+3. [`fragments`](#data-fragments) - additional content for the DOM
+
+### `data.location`
+
+If `location` is found in the response JSON payload, it is expected to be a URL
+and the browser is immediately redirected to that location. No additional HTML
+processing is performed.
+
+### `data.html`
+
+The `data.html` response element is typically used for insertion or replacement
+of existing DOM element content. Exactly how `data.html` is used depends on one
+or more processing directives.
+
+#### `data.html` Processing Directives
+
+Processing directives are defined by attributes added to the event-handling `class="ajax"` element.
+They are linked to handlers as described in [Handlers: A Framework](#handlers-a-framework).
+
+Each processing directive is assigned a CSS selector. Since a CSS selector
+can be written to address multiple different blocks on the page at the same time,
+large segments of the DOM can be modified with each directive.
+
+All processing directives are executed for each event and any number of directives may be combined.
+ 
+##### data-append
+
+Append response JSON `data.html` to the element(s) found in the specified CSS selector.
+
+```html
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-append=".done-list">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+##### data-clear
+
+Clear the `.html` attribute of each DOM element found in the specified CSS selector.
+
+```html
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-clear=".done-status">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+##### data-clear-closest
+
+Invoke `data-clear` functionality using jQuery's `closest` method to interpret the selector.
+
+##### data-prepend
+
+Prepend response JSON `data.html` to the element(s) found in the specified CSS selector.
+
+```html
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-prepend=".done-list">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+##### data-refresh
+
+Define which elements get **_refreshed_**.
+Matching elements are refreshed with the contents of the url defined in their `data-refresh-url`
+attribute.
+
+```html
+<div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
+
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-refresh=".done-score">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+In this example, `.done-score` will fetch (GET) JSON from the url defined
+by `data-refresh-url`, then replace itself with the contents of response JSON `data.html`.
+
+##### data-refresh-closest
+
+Invoke `data-refresh` functionality using jQuery's `closest` method to interpret the selector.
+
+##### data-remove
+
+Remove DOM elements found in the specified CSS selector.
+
+```html
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-remove=".done-status">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+##### data-remove-closest
+
+Invoke `data-remove` functionality using jQuery's `closest` method to interpret the selector.
+
+##### data-replace
+
+Replace the element(s) found in the specified CSS selector with response JSON `data.html`.
+
+```html
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-replace=".done-status">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+##### data-replace-closest
+
+Invoke `data-replace` functionality using jQuery's `closest` method to interpret the selector.
+
+##### data-replace-closest-inner
+
+Invoke `data-replace-inner` functionality using jQuery's `closest` method to interpret the selector.
+
+##### data-replace-inner
+
+Similar to `data-replace` functionality, but replaces the element(s) `.html` attribute.
+
+#### A Complex `data.html` Processing Directive Example
+
+This example shows combined use of `data-append`, `data-refresh`, and `data-remove` attributes
+as `data.html` processing directives.
+
+```html
+<div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
+
+<div class="done-list">...</div>
+
+<div class="results"></div>
+
+<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
+                                                          data-append=".done-list"
+                                                          data-refresh=".done-score"
+                                                          data-remove=".results">
+    <i class="fa fa-fw fa-check"></i>
+    Done
+</a>
+```
+
+It is rare to use many processing directives combined like this. Usually just one or two
+suffice.
+
+### `data.fragments`
+
+Response JSON `data.fragments` should contain a list of key/value
+pairs where keys are the selectors to content that will be replaced, and
+values are the server-side rendered HTML content replacing elements
+that match the selection.
+
+#### `data.append-fragments`
+
+Similar to `data.fragments`. Each fragment value is appended to the element(s) found in the key CSS selector.
+
+#### `data.inner-fragments`
+
+Similar to `data.fragments`. Each fragment value replaces the `.html` attribute for the element(s) found in the key CSS selector.
+
+#### `data.prepend-fragments`
+
+Similar to `data.fragments`. Each fragment value is prepended to the element(s) found in the key CSS selector
+
+## Action Attributes
+
+The following attributes are used by eldarion-ajax when processing supported [Actions](#actions).
+
+##### data-cancel-closest
+
+Used on an `<a>` anchor tag, triggers the `cancel` event handler, which removes
+from the DOM any elements found in the specified CSS selector.
+
+```html
+<a href="#" data-cancel-closest=".edit-form" class="btn btn-secondary ajax">
+    Cancel
+</a>
+```
+
+##### data-method
+
+Defines the request method, i.e. "GET" or "POST".
+
+```html
+<a href="/tasks/2323/delete/" class="ajax" data-method="post">
+```
+
+##### data-refresh-url
+
+Specify a URL which will return HTML content for the element.
+
+```html
+<div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
+```
+
+### Response Data Pro Tip
+
+Both `data.html` and `data.fragments` are processed in a single response.
+This gives you the ability to replace a submitted form with `data.html` content
+while also updating multiple fragments of content on the page.
+
+
 ## Handlers: A Framework
 
-The events provided above allow you to roll your own handlers in such a way to
-really customize how you want your application to respond to server responses. A
-lot have been provided (see the section below), but here is a quick primer on
-writing your own.
+The eldarion-ajax [events](#events) allow you to code handlers which
+customize actions for server responses. Many handlers are included
+(see [`html` Processing Directives](#html-processing-directives)),
+but here is a quick primer for writing your own.
 
 ```javascript
 $(function ($) {
@@ -233,139 +447,8 @@ $(function ($) {
 ```
 
 This gives you a lot of flexibility. For example, if you don't like how the
-batteries included approach treats server response data, you can drop the
-inclusion of `eldarion-ajax-handlers.js` and roll your own.
-
-
-## Handlers: Batteries Included
-
-There are three data attributes looked for in the response JSON data:
-
-1. `location`
-2. `html`
-3. `fragments`
-
-If `location` is found in the response JSON payload, it is expected to be a URL
-and the browser will be immediately redirected to that location. If, on the other hand
-it is not present, then the processing rules below will be processed based on
-what attributes are defined.
-
-If you have a `fragments` hash defined, it should contain a list of key/value
-pairs where the keys are the selectors to content that will be replaced, and the
-values are the server-side rendered HTML content that will replace the elements
-that match the selection.
-
-You can define both `html` to be processed by the declaritive rules defined
-below and the `fragements` at the same time. This gives you the ability to
-for example replace the form you submited with `html` content while at the
-same time updating multiple bits of content on the page without having to
-refresh them.
-
-There are five different ways that you can declare an `html` response
-without a `location` directive be processed:
-
-1. Append
-2. Prepend
-3. Refresh
-4. Refresh Closest
-5. Replace
-6. Replace Closest
-
-Here is where it can get fun as all of the values for these processing directives are
-just CSS selectors. In addition they can be multiplexed. You can declare all of them
-at the same time if you so desire. A CSS selector can easily be written to address
-multiple different blocks on the page at the same time.
-
-Best to just see some examples.
-
-### Append
-
-Using `data-append` allows you to specify that the `data.html` returned in the
-server response's JSON be appended to the elements found in the specified CSS
-selector:
-
-```html
-<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
-                                                          data-append=".done-list">
-    <i class="fa fa-fw fa-check"></i>
-    Done
-</a>
-```
-
-### Prepend
-
-Using `data-prepend` allows you to specify that the `data.html` returned in the
-server response's JSON be prepended to the elements found in the specified CSS
-selector:
-
-```html
-<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
-                                                          data-append=".done-list">
-    <i class="fa fa-fw fa-check"></i>
-    Done
-</a>
-```
-
-### Refresh
-
-Using the `data-refresh` attribute lets you define what elements, if selected by the
-CSS selector specified for its value, get **_refreshed_**. Elements that are selected will
-get refreshed with the contents of the url defined in their `data-refresh-url`
-attribute:
-
-```html
-<div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
-
-<div class="done-list">...</div>
-
-<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
-                                                          data-append=".done-list"
-                                                          data-refresh=".done-score">
-    <i class="fa fa-fw fa-check"></i>
-    Done
-</a>
-```
-
-In this example, the `.done-list` will be appended to with the `data.html` returns from
-the AJAX post made as a result of clicking the button and simultaneously, the `.done-score`
-will refresh itself by fetching (GET) JSON from the url defined in `data-refresh-url` and
-replacing itself with the contents of `data.html` that is returned.
-
-### Refresh Closest
-
-This works very much in the same way as `data-refresh` however, the uses jQuery's `closest`
-method to interpret the selector.
-
-### Replace
-
-Sometimes you want to neither refresh nor append to existing elements but you want to just replace
-the content with whatever it is that is returned from the server. This is what `data-replace`
-is for.
-
-### Replace Closest
-
-This works very much in the same way as `data-replace` however, the uses jQuery's `closest`
-method to interpret the selector.
-
-```html
-<div class="done-score" data-refresh-url="/users/paltman/done-score/">...</div>
-
-<div class="done-list">...</div>
-
-<div class="results"></div>
-
-<a href="/tasks/12342/done/" class="btn btn-primary ajax" data-method="post"
-                                                          data-append=".done-list"
-                                                          data-refresh=".done-score"
-                                                          data-replace=".results">
-    <i class="fa fa-fw fa-check"></i>
-    Done
-</a>
-```
-
-It is rare that you'll add/use all of these processing methods combined like this. Usually it will
-just be one or the other, however, I add them all here to illustrate the point that they are
-independently interpreted and executed.
+batteries included approach treats server response data, you can drop
+inclusion of `eldarion-ajax-handlers.js` and write your own handlers.
 
 
 ## Commercial Support

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ change the data at all, you must return new data from the function handling the
 event. Otherwise, the original data will be used.
 
 
-## Response Handling
+## Responses
 
 There are three data attributes looked for in the response JSON.
 
@@ -230,8 +230,6 @@ The `data.html` response element is typically used for insertion or replacement
 of existing DOM element content. Exactly how `data.html` is used depends on one
 or more processing directives.
 
-#### `data.html` Processing Directives
-
 Processing directives are defined by attributes added to the event-handling `class="ajax"` element.
 They are linked to handlers as described in [Handlers: A Framework](#handlers-a-framework).
 
@@ -240,8 +238,10 @@ can be written to address multiple different blocks on the page at the same time
 large segments of the DOM can be modified with each directive.
 
 All processing directives are executed for each event and any number of directives may be combined.
+
+### Processing Directives
  
-##### data-append
+#### data-append
 
 Append response JSON `data.html` to the element(s) found in the specified CSS selector.
 
@@ -253,7 +253,7 @@ Append response JSON `data.html` to the element(s) found in the specified CSS se
 </a>
 ```
 
-##### data-clear
+#### data-clear
 
 Clear the `.html` attribute of each DOM element found in the specified CSS selector.
 
@@ -265,11 +265,11 @@ Clear the `.html` attribute of each DOM element found in the specified CSS selec
 </a>
 ```
 
-##### data-clear-closest
+#### data-clear-closest
 
 Invoke `data-clear` functionality using jQuery's `closest` method to interpret the selector.
 
-##### data-prepend
+#### data-prepend
 
 Prepend response JSON `data.html` to the element(s) found in the specified CSS selector.
 
@@ -281,7 +281,7 @@ Prepend response JSON `data.html` to the element(s) found in the specified CSS s
 </a>
 ```
 
-##### data-refresh
+#### data-refresh
 
 Define which elements get **_refreshed_**.
 Matching elements are refreshed with the contents of the url defined in their `data-refresh-url`
@@ -300,11 +300,11 @@ attribute.
 In this example, `.done-score` will fetch (GET) JSON from the url defined
 by `data-refresh-url`, then replace itself with the contents of response JSON `data.html`.
 
-##### data-refresh-closest
+#### data-refresh-closest
 
 Invoke `data-refresh` functionality using jQuery's `closest` method to interpret the selector.
 
-##### data-remove
+#### data-remove
 
 Remove DOM elements found in the specified CSS selector.
 
@@ -316,11 +316,11 @@ Remove DOM elements found in the specified CSS selector.
 </a>
 ```
 
-##### data-remove-closest
+#### data-remove-closest
 
 Invoke `data-remove` functionality using jQuery's `closest` method to interpret the selector.
 
-##### data-replace
+#### data-replace
 
 Replace the element(s) found in the specified CSS selector with response JSON `data.html`.
 
@@ -332,19 +332,19 @@ Replace the element(s) found in the specified CSS selector with response JSON `d
 </a>
 ```
 
-##### data-replace-closest
+#### data-replace-closest
 
 Invoke `data-replace` functionality using jQuery's `closest` method to interpret the selector.
 
-##### data-replace-closest-inner
+#### data-replace-closest-inner
 
 Invoke `data-replace-inner` functionality using jQuery's `closest` method to interpret the selector.
 
-##### data-replace-inner
+#### data-replace-inner
 
 Similar to `data-replace` functionality, but replaces the element(s) `.html` attribute.
 
-#### A Complex `data.html` Processing Directive Example
+### A Complex `data.html` Processing Directive Example
 
 This example shows combined use of `data-append`, `data-refresh`, and `data-remove` attributes
 as `data.html` processing directives.
@@ -425,11 +425,11 @@ This gives you the ability to replace a submitted form with `data.html` content
 while also updating multiple fragments of content on the page.
 
 
-## Handlers: A Framework
+## Handlers: A Batteries Included Framework
 
 The eldarion-ajax [events](#events) allow you to code handlers which
 customize actions for server responses. Many handlers are included
-(see [`html` Processing Directives](#html-processing-directives)),
+(see [Processing Directives](#processing-directives)),
 but here is a quick primer for writing your own.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Similar to `data.fragments`. Each fragment value is prepended to the element(s) 
 
 The following attributes are used by eldarion-ajax when processing supported [Actions](#actions).
 
-##### data-cancel-closest
+#### data-cancel-closest
 
 Used on an `<a>` anchor tag, triggers the `cancel` event handler, which removes
 from the DOM any elements found in the specified CSS selector.
@@ -402,7 +402,7 @@ from the DOM any elements found in the specified CSS selector.
 </a>
 ```
 
-##### data-method
+#### data-method
 
 Defines the request method, i.e. "GET" or "POST".
 
@@ -410,7 +410,7 @@ Defines the request method, i.e. "GET" or "POST".
 <a href="/tasks/2323/delete/" class="ajax" data-method="post">
 ```
 
-##### data-refresh-url
+#### data-refresh-url
 
 Specify a URL which will return HTML content for the element.
 


### PR DESCRIPTION
Add missing `html` processing directives.
Add additional `fragments` response types.
Use full attribute names in doc headers.
Outline action-based element attributes.